### PR TITLE
Add dockerfile for running JointTG

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM adnrv/opencv:3.4
+
+RUN apt-get install -y libflann-dev libboost-system-dev libboost-filesystem-dev libomp-dev
+
+COPY bin/JointTG /usr/bin/JointTG
+
+COPY lib /usr/lib


### PR DESCRIPTION
The given binary has to be running in ubuntu 16.04, with all the dependencies
installed. However most of us use a newer version of ubuntu today. It is very
painful to download and install all the dependencies manually.

Also, `libJointTexGeo.so` has a shared object dependency of opencv 3.4, which is
not listed in README.

```
$ ldd lib/libJointTexGeo.so
        linux-vdso.so.1 (0x00007ffc83794000)
        libopencv_core.so.3.4 => not found
        libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007fdafd964000)
        libflann.so.1.9 => not found
        libjpeg.so.8 => /usr/lib/x86_64-linux-gnu/libjpeg.so.8 (0x00007fdafd6fc000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fdafd4dd000)
        libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007fdafd0d0000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fdafcd32000)
        libomp.so.5 => not found
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007fdafcb1a000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fdafc729000)
        /lib64/ld-linux-x86-64.so.2 (0x00007fdafe66f000)
```

Opencv 3.4 is not available in official ubuntu 16.04 repository, so users must
download and install opencv 3.4 manually.

This pr adds a dockerfile for building an environment that is able to run
JointTG with a single command.

I have built an image using this dockerfile already. You can download and test it.

``` sh
docker pull nasen23/jointtg
docker run -it --mount=<your-volume-mount> nasen23/jointtg /bin/bash
# Inside docker container, run JointTG directly
JointTG
```